### PR TITLE
Make middle of the word replacements not happen

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -13,19 +13,26 @@ var writeUserMap = function() {
 };
 
 module.exports = {
-  ircToSlack: function(originalMessage) {
+  ircToSlack: function (originalMessage) {
     var modifiedMessage = originalMessage;
-    _.each(userMap, function(val, key, list) {
-      var re = new RegExp("@?" + key, 'gi');
-      var urlRegex = /https?:\/\//
-      var words = modifiedMessage.split(' ');
+    var urlRegex = /https?:\/\//;
+    var words = modifiedMessage.split(' ');
+    _.each(userMap, function (val, key, list) {
       var replaced = words.map(function (word) {
         if (urlRegex.test(word)) {
           return word;
         } else {
-          return word.replace(re, "<@" + val + ">");
+          var re = new RegExp('\\b' + key + '\\b', 'i');
+          if (re.test(word)) {
+            if (word.indexOf('@') > -1) {
+              key = '@' + key;
+            }
+            return word.replace(key, '<@' + val + '>');
+          } else {
+            return word;
+          }
         }
-      })
+      });
       modifiedMessage = replaced.join(' ');
     });
     return modifiedMessage;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Rdio IRC bot",
   "main": "lib/main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha -R spec ./test/**/*.test.js"
   },
   "author": "rknLA",
   "license": "MIT",

--- a/test/mapping.test.js
+++ b/test/mapping.test.js
@@ -18,19 +18,64 @@ describe('Mapping', function () {
 
   describe('ircToSlack', function () {
     before(function () {
-      mapping.link('slackname', 'ircusername');
+      mapping.link('coolname', 'rob');
     });
 
     after(function () {
-      mapping.unlink('slackname', 'ircusername');
-    })
+      mapping.unlink('coolname', 'rob');
+    });
 
     it('does not replace names in URLS', function () {
-      var message = 'Check out http://github.com/ircusername/coolrepo';
+      var message = 'Check out http://github.com/rob/coolrepo';
       var newMessage = mapping.ircToSlack(message);
       expect(newMessage).to.equal(message);
     });
 
-  });
+    it('allows replacement of words outside of a url', function () {
+      var message = 'rob: Check out http://github.com/rob/coolrepo';
+      var newMessage = mapping.ircToSlack(message);
+      var expected = '<@coolname>: Check out http://github.com/rob/coolrepo';
+      expect(newMessage).to.equal(expected);
+    });
 
-})
+    it('does not replace names in the middle of other words', function () {
+      var message = 'Worry, not it is not a problem';
+      var newMessage = mapping.ircToSlack(message);
+      expect(newMessage).to.equal(message);
+    });
+
+    it('does the replacement with a non-letter character afterwards', function () {
+      var message = 'rob: what is the plan?';
+      var newMessage = mapping.ircToSlack(message);
+      expect(newMessage).to.equal('<@coolname>: what is the plan?');
+    });
+
+    it('does the replacement when the message is just a one word question', function () {
+      var message = 'rob?';
+      var newMessage = mapping.ircToSlack(message);
+      expect(newMessage).to.equal('<@coolname>?');
+    });
+
+    it('does not replace it at the end of of a word', function () {
+      var message = 'throb is a verb or a noun';
+      var newMessage = mapping.ircToSlack(message);
+      expect(newMessage).to.equal(message);
+    });
+
+    it('it replaces the message if it is a single highlight word', function () {
+      var message = 'rob';
+      var newMessage = mapping.ircToSlack(message);
+      expect(newMessage).to.equal('<@coolname>');
+    });
+
+    it('replaces the word with a @ before it', function () {
+      var message = 'hey @rob';
+      var newMessage = mapping.ircToSlack(message);
+      expect(newMessage).to.equal('hey <@coolname>');
+    })
+
+
+
+
+  });
+});


### PR DESCRIPTION
This makes a match require a non-letter character to come after the name, so if the name is `rob`. It won't get replaced in words like `problem`, but it will get replaced in messages such as `rob: what are you doing` and `rob?`
