### PR TITLE
Add travis.yml file for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+os:
+  - linux
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4.0"
+script:
+  - "npm test"


### PR DESCRIPTION
I think it'd be great if we could get a Travis build running.

It'll require someone with privileges on the repo to make it start running, but this should make things magically work once it's enabled.
